### PR TITLE
Fix stock conversions using beancount.core.convert.get_weight()

### DIFF
--- a/irr.py
+++ b/irr.py
@@ -143,8 +143,6 @@ if __name__ == '__main__':
 
     entries, errors, options = beancount.loader.load_file(args.bean, logging.info, log_errors=sys.stderr)
 
-    if not args.date_from:
-        args.date_from = datetime.date.min
     if not args.date_to:
         args.date_to = datetime.date.today()
 
@@ -163,7 +161,7 @@ if __name__ == '__main__':
         pprint([(f.date, f.amount) for f in cashflows])
     if args.debug_inflows:
         print('>> [inflows]')
-        pprint(set().union(*[f.inflows for f in cashflows]))
+        pprint(set().union(*[f.inflow_accounts for f in cashflows]))
     if args.debug_outflows:
         print('<< [outflows]')
-        pprint(set().union(*[f.outflows for f in cashflows]))
+        pprint(set().union(*[f.outflow_accounts for f in cashflows]))

--- a/test_cashflows.py
+++ b/test_cashflows.py
@@ -74,3 +74,114 @@ class TestCashflows(unittest.TestCase):
             internal_accounts=['Income:CapitalGains'], date_from=datetime.date(2015, 12, 1),
             date_to=datetime.date(2017, 12, 1), currency='USD')
         self.assertEqual(expected_cashflows, simplify_cashflows(actual_cashflows))
+
+        # Test 'date_from=None', which should be equivalent.
+        actual_cashflows = get_cashflows(
+            entries=entries, interesting_accounts=['Assets:Brokerage'],
+            internal_accounts=['Income:CapitalGains'], date_from=None,
+            date_to=datetime.date(2017, 12, 1), currency='USD')
+        self.assertEqual(expected_cashflows, simplify_cashflows(actual_cashflows))
+
+    @loader.load_doc()
+    def test_stock_conversion(self, entries, errors, options_map):
+        """
+        2018-01-01 commodity USD
+        2018-01-01 commodity HOOLI
+
+        2018-01-01 open Assets:Brokerage
+        2018-01-01 open Assets:Cash
+
+        2018-01-01 * "Buy"
+           Assets:Brokerage 100 HOOLI {1 USD}
+           Assets:Cash
+
+        2018-04-01 commodity IOOLI
+
+        2018-04-01 * "Conversion"
+           Assets:Brokerage -100 HOOLI {}
+           Assets:Brokerage 50 IOOLI {2 USD}
+
+        2018-12-31 price HOOLI 1.5 USD
+        2018-12-31 price IOOLI 3 USD
+        """
+        expected_cashflows = [
+            Cashflow(
+                date=datetime.date(2018, 1, 1),
+                amount=Decimal(100),
+                inflow_accounts=set(['Assets:Cash']),
+            ),
+            Cashflow(
+                date=datetime.date(2018, 12, 31),
+                amount=Decimal(-150),
+            ),
+        ]
+        actual_cashflows = get_cashflows(
+            entries=entries, interesting_accounts=['Assets:Brokerage'], internal_accounts=[],
+            date_from=datetime.date(2018, 1, 1), date_to=datetime.date(2018, 12, 31),
+            currency='USD')
+        self.assertEqual(expected_cashflows, simplify_cashflows(actual_cashflows))
+
+    @loader.load_doc()
+    def test_multi_currency(self, entries, errors, options_map):
+        """
+        1792-01-01 commodity USD
+        1999-01-01 commodity EUR
+        2015-12-01 commodity ABC
+
+        2015-12-01 open Equity:Opening-Balances
+        2015-12-01 open Assets:Brokerage
+        2015-12-01 open Assets:Cash
+        2015-12-01 open Income:CapitalGains
+        2015-12-01 open Income:Dividends
+
+        2015-12-01 * "Opening balance"
+            Assets:Cash           3,000 USD
+            Equity:Opening-Balances
+
+        2015-12-01 price EUR 2 USD
+
+        2015-12-01 * "Buy in EUR"
+            Assets:Brokerage      500 ABC {1.00 EUR}
+            Assets:Cash          -1,000 USD @ 0.5 EUR
+
+        2016-06-01 * "Receive dividend in EUR"
+            Assets:Brokerage        50 EUR
+            Income:Dividends       -100 USD @ 0.5 EUR
+
+        2016-12-01 price EUR 1 USD
+
+        2016-12-01 * "Buy more in EUR"
+            Assets:Brokerage      1,000 ABC {2.00 EUR}
+            Assets:Cash          -2,000 USD @ 1 EUR
+
+        2018-12-01 * "Sell and withdraw all holdings"
+            Assets:Brokerage       -500 ABC {1.00 EUR}
+            Assets:Brokerage     -1,000 ABC {2.00 EUR}
+            Assets:Brokerage        -50 EUR
+            Income:CapitalGains  -1,000 USD @ 1 EUR
+            Assets:Cash           3,550 USD @ 1 EUR
+        """
+        expected_cashflows = [
+            Cashflow(
+                date=datetime.date(2015, 12, 1),
+                amount=Decimal('1000.00'),
+                inflow_accounts=set(['Assets:Cash']),
+            ),
+            Cashflow(
+                date=datetime.date(2016, 12, 1),
+                amount=Decimal('2000.00'),
+                inflow_accounts=set(['Assets:Cash']),
+            ),
+            Cashflow(
+                date=datetime.date(2018, 12, 1),
+                amount=Decimal('-3550.00'),
+                outflow_accounts=set(['Assets:Cash']),
+            ),
+        ]
+        actual_cashflows = get_cashflows(
+            entries=entries, interesting_accounts=['Assets:Brokerage'],
+            internal_accounts=['Income:CapitalGains', 'Income:Dividends'],
+            date_from=datetime.date(2015, 12, 1), date_to=datetime.date(2018, 12, 1),
+            currency='USD')
+        self.maxDiff = None
+        self.assertEqual(expected_cashflows, simplify_cashflows(actual_cashflows))


### PR DESCRIPTION
We currently use `beancount.core.convert.convert_position()` to convert a posting's Amount to the target currency. Issue #3 identified several situations where this can produce incorrect results:

1. In stock conversions, positions are exchanged at cost, which may differ from the price on the day of the conversion. This can cause transactions to falsely appear not to balance when `convert_position()` is used.
2. Not all prices are known at all times.

This PR fixes the issue by using `beancount.core.convert.get_weight()` to do the conversion instead. This is the same function that Beancount internally uses to determine whether a transaction balances. For single-currency ledgers, we now only require price information to determine the starting and ending balances, not to derive the cashflows in between.

Additionally, this PR makes the following smaller fixes, all of which are covered by new tests:
- If the weight's currency differs from the user's desired currency, we must still use `beancount.core.convert.convert_amount()` to do the currency conversion at the appropriate price.
- There is an edge case where the first inflow occurs on the start date but accurate price information is not available at that time. In that case, the total start value on that date will be calculated incorrectly. The fix is to calculate the total start value on the previous date (i.e., at the beginning of the start date). This means we can no longer accept a start date of `datetime.date.min` since it would now cause underflow.

Fixes #3.